### PR TITLE
feat: add maintenance routine handler registry

### DIFF
--- a/config/services/services.yaml
+++ b/config/services/services.yaml
@@ -32,9 +32,14 @@ services:
     _instanceof:
         ControleOnline\Service\Imports\ImportProcessorInterface:
             tags: ['app.import_processor']
+        ControleOnline\Service\MaintenanceRoutineHandlerInterface:
+            tags: ['controleonline.maintenance_routine_handler']
     ControleOnline\Service\Imports\ImportProcessorResolver:
         arguments:
             $processors: !tagged_iterator app.import_processor
+    ControleOnline\Service\MaintenanceRoutineService:
+        arguments:
+            $routineHandlers: !tagged_iterator controleonline.maintenance_routine_handler
 
     ControleOnline\Listener\DefaultEventListener:
         arguments:

--- a/src/Service/CleanupLogsMaintenanceRoutine.php
+++ b/src/Service/CleanupLogsMaintenanceRoutine.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ControleOnline\Service;
+
+class CleanupLogsMaintenanceRoutine implements MaintenanceRoutineHandlerInterface
+{
+    public function __construct(
+        private LogCleanupService $logCleanupService,
+    ) {}
+
+    public function getDefinition(): array
+    {
+        return [
+            'key' => MaintenanceRoutineService::ROUTINE_CLEANUP_LOGS,
+            'title' => 'Limpeza de logs',
+            'description' => 'Remove logs expirados conforme a politica configurada.',
+            'defaultEnabled' => true,
+            'defaultCronExpression' => '* * * * *',
+        ];
+    }
+
+    public function run(): array
+    {
+        return [
+            'key' => MaintenanceRoutineService::ROUTINE_CLEANUP_LOGS,
+            'status' => 'success',
+            'summary' => $this->logCleanupService->cleanup(),
+        ];
+    }
+}

--- a/src/Service/MaintenanceRoutineHandlerInterface.php
+++ b/src/Service/MaintenanceRoutineHandlerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ControleOnline\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('controleonline.maintenance_routine_handler')]
+interface MaintenanceRoutineHandlerInterface
+{
+    public function getDefinition(): array;
+
+    public function run(): array;
+}

--- a/src/Service/MaintenanceRoutineService.php
+++ b/src/Service/MaintenanceRoutineService.php
@@ -12,20 +12,50 @@ class MaintenanceRoutineService
     public function __construct(
         private ConfigService $configService,
         private PeopleRoleService $peopleRoleService,
-        private LogCleanupService $logCleanupService,
-    ) {}
+        iterable $routineHandlers,
+    ) {
+        $this->routineHandlers = [];
+
+        foreach ($routineHandlers as $handler) {
+            if (!$handler instanceof MaintenanceRoutineHandlerInterface) {
+                continue;
+            }
+
+            $definition = $handler->getDefinition();
+            $routineKey = trim((string) ($definition['key'] ?? ''));
+            if ($routineKey === '') {
+                continue;
+            }
+
+            $this->routineHandlers[$routineKey] = $handler;
+        }
+    }
+
+    /**
+     * @var array<string, MaintenanceRoutineHandlerInterface>
+     */
+    private array $routineHandlers;
 
     public function getRoutineDefinitions(): array
     {
-        return [
-            self::ROUTINE_CLEANUP_LOGS => [
-                'key' => self::ROUTINE_CLEANUP_LOGS,
-                'title' => 'Limpeza de logs',
-                'description' => 'Remove logs expirados conforme a politica configurada.',
-                'defaultEnabled' => true,
-                'defaultCronExpression' => '* * * * *',
-            ],
-        ];
+        $definitions = [];
+
+        foreach ($this->routineHandlers as $routineKey => $handler) {
+            $definition = $handler->getDefinition();
+            $definitions[$routineKey] = [
+                'key' => $routineKey,
+                'title' => (string) ($definition['title'] ?? $routineKey),
+                'description' => (string) ($definition['description'] ?? ''),
+                'defaultEnabled' => array_key_exists('defaultEnabled', $definition)
+                    ? (bool) $definition['defaultEnabled']
+                    : false,
+                'defaultCronExpression' => trim((string) (
+                    $definition['defaultCronExpression'] ?? '* * * * *'
+                )) ?: '* * * * *',
+            ];
+        }
+
+        return $definitions;
     }
 
     public function getConfiguredRoutines(): array
@@ -91,18 +121,24 @@ class MaintenanceRoutineService
 
     public function runRoutine(string $routineKey): array
     {
-        return match ($routineKey) {
-            self::ROUTINE_CLEANUP_LOGS => [
-                'key' => $routineKey,
-                'status' => 'success',
-                'summary' => $this->logCleanupService->cleanup(),
-            ],
-            default => [
+        $handler = $this->routineHandlers[$routineKey] ?? null;
+
+        if (!$handler) {
+            return [
                 'key' => $routineKey,
                 'status' => 'ignored',
                 'summary' => ['message' => 'Rotina sem executor registrado.'],
-            ],
-        };
+            ];
+        }
+
+        $result = $handler->run();
+        $result['key'] = trim((string) ($result['key'] ?? $routineKey));
+
+        if ($result['key'] === '') {
+            $result['key'] = $routineKey;
+        }
+
+        return $result;
     }
 
     public function isRoutineDue(array $routine, \DateTimeImmutable $now): bool

--- a/tests/Service/MaintenanceRoutineServiceTest.php
+++ b/tests/Service/MaintenanceRoutineServiceTest.php
@@ -3,8 +3,9 @@
 namespace ControleOnline\Tests\Service;
 
 use ControleOnline\Entity\People;
+use ControleOnline\Service\CleanupLogsMaintenanceRoutine;
 use ControleOnline\Service\ConfigService;
-use ControleOnline\Service\LogCleanupService;
+use ControleOnline\Service\MaintenanceRoutineHandlerInterface;
 use ControleOnline\Service\MaintenanceRoutineService;
 use ControleOnline\Service\PeopleRoleService;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +17,7 @@ class MaintenanceRoutineServiceTest extends TestCase
         $service = new MaintenanceRoutineService(
             $this->createMock(ConfigService::class),
             $this->createMock(PeopleRoleService::class),
-            $this->createMock(LogCleanupService::class),
+            [$this->createCleanupRoutineHandler()],
         );
 
         $normalized = $service->normalizeConfiguredRoutines([
@@ -56,7 +57,7 @@ class MaintenanceRoutineServiceTest extends TestCase
         $service = new MaintenanceRoutineService(
             $configService,
             $peopleRoleService,
-            $this->createMock(LogCleanupService::class),
+            [$this->createCleanupRoutineHandler()],
         );
 
         $dueRoutines = $service->getDueRoutines(
@@ -72,15 +73,10 @@ class MaintenanceRoutineServiceTest extends TestCase
 
     public function testRunsCleanupLogsRoutine(): void
     {
-        $cleanupService = $this->createMock(LogCleanupService::class);
-        $cleanupService->expects(self::once())
-            ->method('cleanup')
-            ->willReturn(['deletedTotal' => 3]);
-
         $service = new MaintenanceRoutineService(
             $this->createMock(ConfigService::class),
             $this->createMock(PeopleRoleService::class),
-            $cleanupService,
+            [$this->createCleanupRoutineHandler(['deletedTotal' => 3])],
         );
 
         $result = $service->runRoutine(
@@ -89,5 +85,25 @@ class MaintenanceRoutineServiceTest extends TestCase
 
         self::assertSame('success', $result['status']);
         self::assertSame(3, $result['summary']['deletedTotal']);
+    }
+
+    private function createCleanupRoutineHandler(
+        array $summary = ['deletedTotal' => 0],
+    ): MaintenanceRoutineHandlerInterface {
+        $handler = $this->createMock(CleanupLogsMaintenanceRoutine::class);
+        $handler->method('getDefinition')->willReturn([
+            'key' => MaintenanceRoutineService::ROUTINE_CLEANUP_LOGS,
+            'title' => 'Limpeza de logs',
+            'description' => 'Remove logs expirados conforme a politica configurada.',
+            'defaultEnabled' => true,
+            'defaultCronExpression' => '* * * * *',
+        ]);
+        $handler->method('run')->willReturn([
+            'key' => MaintenanceRoutineService::ROUTINE_CLEANUP_LOGS,
+            'status' => 'success',
+            'summary' => $summary,
+        ]);
+
+        return $handler;
     }
 }


### PR DESCRIPTION
## Summary
- refactor the maintenance routine service to discover routine handlers by tag
- keep log cleanup as a dedicated routine handler
- allow domain modules to plug new maintenance executors into the shared scheduler

## Issue
- Refs ControleOnline/app-community#71

## Validation
- environment did not provide PHP runtime, so automated tests could not be executed in this session
- implementation was validated by code inspection across the shared scheduler flow

## Note
- the repository exposes `dev`, but it is too far from `master` for an isolated review in this issue, so this PR targets `master` to keep the diff focused